### PR TITLE
changed line dash to improve accessibility

### DIFF
--- a/examples/basic/annotations/span.py
+++ b/examples/basic/annotations/span.py
@@ -11,9 +11,9 @@ p.y_range.start = 0
 p.y_range.end = 24 * 60 * 60 * 1000
 
 p.line("Date", "Sunset", source=daylight_warsaw_2013,
-       color='navy',legend_label="Sunset")
+       color='navy', line_dash="dotted", line_width=2, legend_label="Sunset")
 p.line("Date", "Sunrise", source=daylight_warsaw_2013,
-       color='orange', legend_label="Sunrise")
+       color='orange', line_dash="dashed", line_width=2, legend_label="Sunrise")
 
 dst_start = Span(location=dt(2013, 3, 31, 2, 0, 0), dimension='height',
                  line_color='#009E73', line_width=5)


### PR DESCRIPTION
For Issue: [Improve usability with color vision deficiencies #11481](https://github.com/bokeh/bokeh/issues/11481)

Instead of 2 solid lines, the plot now contains a dashed and a dotted line. The blue and orange is a good color combination, so I did not change that, but sometimes plots are viewed in grayscale, and this would enable the lines to be distinguished in that case. [Avoiding multiple solid lines was recommended here.](https://xdgov.github.io/data-design-standards/) 

Because changing the line dash made the line more faint and difficult to see, I also increased the line width slightly from default (1?) to 2. I’m happy to adjust anything if this is not a viable improvement. 


![Before](https://github.com/fractaldatalearning/kl_bokeh_contributions/blob/main/figures/span.before.png)

![After](https://github.com/fractaldatalearning/kl_bokeh_contributions/blob/main/figures/span.after.png)


I can also create new thumbnail images if this change looks alright. 
